### PR TITLE
Support the key_algorithm argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ module "example_certificate" {
   domain_name = "example.com"
   subject_alternative_names = ["example.com"]
   dns_zone_id = aws_route53_zone.main.zone_id
+  key_algorithm = "EC_prime256v1" # defaults to RSA_2048
+
+  options = {
+    certificate_transparency_logging_preference = "DISABLED" # defaults to ENABLED
+  }
 
   providers = {
     aws = aws.global

--- a/README.md
+++ b/README.md
@@ -9,11 +9,7 @@ module "example_certificate" {
   domain_name = "example.com"
   subject_alternative_names = ["example.com"]
   dns_zone_id = aws_route53_zone.main.zone_id
-  key_algorithm = "EC_prime256v1" # defaults to RSA_2048
-
-  options = {
-    certificate_transparency_logging_preference = "DISABLED" # defaults to ENABLED
-  }
+  key_algorithm = "EC_prime256v1" # Defaults to "RSA_2048".
 
   providers = {
     aws = aws.global

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,11 @@ resource "aws_acm_certificate" "this" {
   domain_name = var.domain_name
   subject_alternative_names = var.subject_alternative_names
   validation_method = "DNS"
+  key_algorithm = var.key_algorithm
+
+  options {
+    certificate_transparency_logging_preference = var.options.certificate_transparency_logging_preference
+  }
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -4,10 +4,6 @@ resource "aws_acm_certificate" "this" {
   validation_method = "DNS"
   key_algorithm = var.key_algorithm
 
-  options {
-    certificate_transparency_logging_preference = var.options.certificate_transparency_logging_preference
-  }
-
   lifecycle {
     create_before_destroy = true
   }

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,23 @@ variable "dns_zone_id" {
   type = string
   nullable = false
 }
+
+variable "key_algorithm" {
+  type = string
+  default = "RSA_2048"
+  nullable = false
+}
+
+variable "options" {
+  type = object({
+    certificate_transparency_logging_preference = string
+  })
+  default = {
+    certificate_transparency_logging_preference = "ENABLED"
+  }
+  nullable = false
+  validation {
+    condition = contains(["ENABLED", "DISABLED"], var.options.certificate_transparency_logging_preference)
+    error_message = "The certificate_transparency_logging_preference must be either 'ENABLED' or 'DISABLED'."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -19,17 +19,3 @@ variable "key_algorithm" {
   default = "RSA_2048"
   nullable = false
 }
-
-variable "options" {
-  type = object({
-    certificate_transparency_logging_preference = string
-  })
-  default = {
-    certificate_transparency_logging_preference = "ENABLED"
-  }
-  nullable = false
-  validation {
-    condition = contains(["ENABLED", "DISABLED"], var.options.certificate_transparency_logging_preference)
-    error_message = "The certificate_transparency_logging_preference must be either 'ENABLED' or 'DISABLED'."
-  }
-}


### PR DESCRIPTION
This pull request adds two new input variables to the `aws_acm_certificate` resource: `key_algorithm`
and `options`.

### Remarks
Both were added with default values to maintain compatibility.